### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,22 @@
+# Copyright René Ferdinand Rivera Morell 2024
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/scope
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/core//boost_core
+        <include>include
+    ;
+
+explicit
+    [ alias boost_scope ]
+    [ alias all : boost_scope test ]
+    ;
+
+call-if : boost-library scope
+    ;

--- a/build.jam
+++ b/build.jam
@@ -12,6 +12,7 @@ project /boost/scope
         <library>/boost/assert//boost_assert
         <library>/boost/config//boost_config
         <library>/boost/core//boost_core
+        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -7,9 +7,9 @@ import project ;
 
 project /boost/scope
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/core//boost_core
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/core//boost_core
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/scope
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -5,19 +5,22 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/core//boost_core
+    /boost/type_traits//boost_type_traits ;
+
 project /boost/scope
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/core//boost_core
-        <library>/boost/type_traits//boost_type_traits
         <include>include
     ;
 
 explicit
-    [ alias boost_scope ]
+    [ alias boost_scope : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_scope test ]
     ;
 
 call-if : boost-library scope
     ;
+

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/scope

--- a/doc/Jamfile
+++ b/doc/Jamfile
@@ -56,7 +56,7 @@ local doxygen_params =
 
 local top_level_includes =
     [ glob
-        ../../../boost/scope/*.hpp
+        ../include/boost/scope/*.hpp
     ] ;
 
 

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -11,6 +11,7 @@ import testing ;
 import path ;
 import regex ;
 import os ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 project

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -15,6 +15,7 @@ import config : requires ;
 
 project
     : requirements
+        <library>/boost/scope//boost_scope
         <include>common
 
         <c++-template-depth>1024

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -5,7 +5,6 @@
 # https://www.boost.org/LICENSE_1_0.txt)
 
 require-b2 5.0.1 ;
-import-search /boost/config/checks ;
 
 import testing ;
 import path ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -4,11 +4,14 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # https://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.0.1 ;
+import-search /boost/config/checks ;
+
 import testing ;
 import path ;
 import regex ;
 import os ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 project
     : requirements
@@ -43,6 +46,8 @@ project
         <target-os>windows:<define>_CRT_SECURE_NO_DEPRECATE
     ;
 
+path-constant SCOPE_INCLUDE_DIR : ../include ;
+
 # this rule enumerates through all the sources and invokes
 # the run rule for each source, the result is a list of all
 # the run rules, which we can pass on to the test_suite rule:
@@ -53,7 +58,7 @@ rule test_all
 
     if ! [ os.environ BOOST_SCOPE_TEST_WITHOUT_SELF_CONTAINED_HEADER_TESTS ]
     {
-        local headers_path = [ path.make $(BOOST_ROOT)/libs/scope/include/boost/scope ] ;
+        local headers_path = [ path.make $(SCOPE_INCLUDE_DIR)/boost/scope ] ;
         for file in [ path.glob-tree $(headers_path) : *.hpp : detail ]
         {
             local rel_file = [ path.relative-to $(headers_path) $(file) ] ;


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.